### PR TITLE
better separation of cli and library

### DIFF
--- a/bin/xunit-viewer
+++ b/bin/xunit-viewer
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const xunitViewer = require('../xunit-viewer')
-const { args } = require('../src/cli/args')
+const args = require('../src/cli/args')
 
-xunitViewer(args)
+args.argv

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ResultsNotFoundError: require('./results_not_found_error')
+}

--- a/src/errors/results_not_found_error.js
+++ b/src/errors/results_not_found_error.js
@@ -1,0 +1,3 @@
+class ResultsNotFoundError extends Error {}
+
+module.exports = ResultsNotFoundError

--- a/xunit-viewer.js
+++ b/xunit-viewer.js
@@ -9,16 +9,16 @@ const watch = require('./src/cli/watch')
 const server = require('./src/cli/server')
 const getSuites = require('./src/cli/get-suites')
 const getDescription = require('./src/cli/get-description')
+const { ResultsNotFoundError } = require('./src/errors')
 
-module.exports = async (args) => {
+module.exports = async args => {
   const logger = Logger(args.noColor)
 
   const results = args.results
   if (!fs.existsSync(results)) {
-    const { showHelp } = require('./src/cli/args')
-    showHelp()
-    console.log(logger.error('\n The folder/file:'), logger.file(results), logger.error('does not exist'))
-    process.exit(1)
+    throw new ResultsNotFoundError(
+      `${logger.error('The folder/file:')} ${logger.file(results)} ${logger.error('does not exist')}`
+    )
   }
 
   const runXunitViewer = async () => {
@@ -31,7 +31,6 @@ module.exports = async (args) => {
       const outputFile = path.resolve(process.cwd(), args.output)
       fs.writeFileSync(outputFile, result)
       console.log('Written to:', logger.file(outputFile))
-      if (!args.server) process.exit(0)
     }
   }
 


### PR DESCRIPTION
library execution via yargs instead of direct call. This ensures correct error handling and makes calling `process.exit()` inside the library obsolete. This results in the library bein usable inside other node script without exiting the whole script (#112).

fixes #112
fixes #94